### PR TITLE
fix(assert): Don't put concrete Predicates in API

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ let temp = assert_fs::TempDir::new().unwrap();
 let input_file = temp.child("foo.txt");
 input_file.touch().unwrap();
 // ... do something with input_file ...
-input_file.assert(predicate::str::is_empty().from_utf8());
+input_file.assert("");
 temp.child("bar.txt").assert(predicate::path::missing());
 temp.close().unwrap();
 ```

--- a/src/assert.rs
+++ b/src/assert.rs
@@ -2,6 +2,7 @@ use std::path;
 
 use predicates;
 use predicates::path::PredicateFileContentExt;
+use predicates::str::PredicateStrExt;
 
 use fs;
 
@@ -17,7 +18,7 @@ use fs;
 /// let input_file = temp.child("foo.txt");
 /// input_file.touch().unwrap();
 /// // ... do something with input_file ...
-/// input_file.assert(predicate::str::is_empty().from_utf8());
+/// input_file.assert("");
 /// temp.child("bar.txt").assert(predicate::path::missing());
 /// temp.close().unwrap();
 /// ```
@@ -80,11 +81,17 @@ where
     }
 }
 
-impl<P> IntoPathPredicate<predicates::path::FileContentPredicate<P>> for P
-where
-    P: predicates::Predicate<[u8]>,
+impl IntoPathPredicate<
+    predicates::path::FileContentPredicate<
+        predicates::str::Utf8Predicate<predicates::ord::EqPredicate<&'static str>>,
+    >,
+> for &'static str
 {
-    fn into_path(self) -> predicates::path::FileContentPredicate<P> {
-        self.from_file_path()
+    fn into_path(
+        self,
+    ) -> predicates::path::FileContentPredicate<
+        predicates::str::Utf8Predicate<predicates::ord::EqPredicate<&'static str>>,
+    > {
+        predicates::ord::eq(self).from_utf8().from_file_path()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@
 //! let input_file = temp.child("foo.txt");
 //! input_file.touch().unwrap();
 //! // ... do something with input_file ...
-//! input_file.assert(predicate::str::is_empty().from_utf8());
+//! input_file.assert("");
 //! temp.child("bar.txt").assert(predicate::path::missing());
 //! temp.close().unwrap();
 //! ```

--- a/tests/assert.rs
+++ b/tests/assert.rs
@@ -10,7 +10,7 @@ fn code_example() {
     let input_file = temp.child("foo.txt");
     input_file.touch().unwrap();
     // ... do something with input_file ...
-    input_file.assert(predicate::str::is_empty().from_utf8());
+    input_file.assert("");
     temp.child("bar.txt").assert(predicate::path::missing());
     temp.close().unwrap();
 }


### PR DESCRIPTION
Eventually `Predicate` is going to move into its own crate so any
breaking change to a predicate will not break `assert_fs`s API.  Having
predicates in the API foils that plan.