### PR TITLE
fix: Remove failure from API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ categories = ["development-tools::testing"]
 keywords = ["filesystem", "test", "assert", "fixture"]
 
 [dependencies]
-failure = "0.1"
 tempfile = "3.0"
 globwalk = "0.3"
 predicates = "0.5"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,13 +1,15 @@
+//! Error types for fixtures.
+
 use std::error::Error;
 use std::fmt;
 
-pub trait ChainError {
+pub(crate) trait ChainError {
     fn chain<F>(self, cause: F) -> Self
     where
         F: Error + Send + Sync + 'static;
 }
 
-pub trait ResultChainExt<T> {
+pub(crate) trait ResultChainExt<T> {
     fn chain<C>(self, chainable: C) -> Result<T, C>
     where
         C: ChainError;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,6 @@
 
 #![warn(missing_docs)]
 
-extern crate failure;
 extern crate globwalk;
 extern crate predicates;
 extern crate tempfile;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,8 +34,7 @@ pub use assert::PathAssert;
 mod fs;
 pub use fs::*;
 
-mod errors;
-pub use errors::FixtureError;
+pub mod errors;
 
 /// Extension traits that are useful to have available.
 pub mod prelude {


### PR DESCRIPTION
This reduces yet another possible area of churn in the API because
failure isn't stable yet.

Fixes #14