### PR TITLE
fix(assert): Show caller for panics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
 
+#### Fixes
+
+- Shiw caller, rather than `assert_fs`, as cause of panics
+
 ## [1.0.4] - 2021-08-30
 
 #### Features
@@ -141,18 +145,18 @@ Stable release!
 #### Features
 
 * **assert:**
-  *  Show cause of failure 
-  *  Support assert(bytes) shorthand 
-  *  Use DifferencePredicate for str 
-  *  Predicate<[u8]> acts on file contents 
+  *  Show cause of failure
+  *  Support assert(bytes) shorthand
+  *  Use DifferencePredicate for str
+  *  Predicate<[u8]> acts on file contents
 
 #### Bug Fixes
 
-*   Bury errors in the docs 
-*   Remove failure from API 
-*   Rename traits to clarify intent 
+*   Bury errors in the docs
+*   Remove failure from API
+*   Rename traits to clarify intent
 * **assert:**
-  *  Isolate API details 
+  *  Isolate API details
 
 
 
@@ -162,20 +166,20 @@ Stable release!
 #### Features
 
 * **assert:**
-  *  Support `assert(bytes)` shorthand 
-  *  Support `assert(str)` shorthand 
+  *  Support `assert(bytes)` shorthand
+  *  Support `assert(str)` shorthand
 * **fixture:**
-  * copy_from now uses gitignore globs 
-  * Improve fixture error reporting 
+  * copy_from now uses gitignore globs
+  * Improve fixture error reporting
 
 #### Bug Fixes
 
 * **fixture:**
-  * `copy_from(".")` failed 
+  * `copy_from(".")` failed
 
 #### Breaking Changes
 
-*   Rename traits to clarify intent 
+*   Rename traits to clarify intent
 
 
 
@@ -189,11 +193,11 @@ Stable release!
 
 #### Bug Fixes
 
-* **fixtures:**  copy_from now works 
+* **fixtures:**  copy_from now works
 
 #### Features
 
-*   Filesystem assertions 
+*   Filesystem assertions
 
 #### Breaking Changes
 
@@ -204,7 +208,7 @@ Stable release!
 
 #### Features
 
-*   Add a prelude 
+*   Add a prelude
 
 
 <!-- next-url -->

--- a/src/assert.rs
+++ b/src/assert.rs
@@ -96,6 +96,7 @@ pub trait PathAssert {
     /// ```
     ///
     /// [`TempDir`]: super::TempDir
+    #[track_caller]
     fn assert<I, P>(&self, pred: I) -> &Self
     where
         I: IntoPathPredicate<P>,
@@ -103,6 +104,7 @@ pub trait PathAssert {
 }
 
 impl PathAssert for fixture::TempDir {
+    #[track_caller]
     fn assert<I, P>(&self, pred: I) -> &Self
     where
         I: IntoPathPredicate<P>,
@@ -114,6 +116,7 @@ impl PathAssert for fixture::TempDir {
 }
 
 impl PathAssert for fixture::NamedTempFile {
+    #[track_caller]
     fn assert<I, P>(&self, pred: I) -> &Self
     where
         I: IntoPathPredicate<P>,
@@ -125,6 +128,7 @@ impl PathAssert for fixture::NamedTempFile {
 }
 
 impl PathAssert for fixture::ChildPath {
+    #[track_caller]
     fn assert<I, P>(&self, pred: I) -> &Self
     where
         I: IntoPathPredicate<P>,
@@ -135,6 +139,7 @@ impl PathAssert for fixture::ChildPath {
     }
 }
 
+#[track_caller]
 fn assert<I, P>(path: &path::Path, pred: I)
 where
     I: IntoPathPredicate<P>,


### PR DESCRIPTION
Thanks to Rust 1.46, we can act like a macro and have panics report the
callers source rather than `assert_fs`

Fixes #64