### PR TITLE
chore: Update `tempfile` dependency to 3.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -324,15 +324,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "rustix"
 version = "0.36.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -357,16 +348,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+checksum = "af18f7ae1acd354b992402e9ec5864359d693cd8a79dcbef59f76891701c1e95"
 dependencies = [
  "cfg-if",
  "fastrand",
- "libc",
  "redox_syscall",
- "remove_dir_all",
- "winapi",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ color = ["dep:yansi", "dep:concolor", "predicates/color"]
 color-auto = ["color", "concolor?/auto"]
 
 [dependencies]
-tempfile = "3.0"
+tempfile = "3.4"
 globwalk = "0.8"
 predicates = { version = "2.0.3", default-features = false, features = ["diff"] }
 predicates-core = "1.0"

--- a/src/fixture/file.rs
+++ b/src/fixture/file.rs
@@ -136,7 +136,7 @@ impl NamedTempFile {
         let mut temp = Inner::Persisted;
         ::std::mem::swap(&mut self.temp, &mut temp);
         if let Inner::Temp(temp) = temp {
-            temp.into_path();
+            let _ = temp.into_path();
         }
 
         self


### PR DESCRIPTION
We use `assert_fs` in our [lading](https://github.com/DataDog/lading) tool and found in a recent dependency update PR --
https://github.com/DataDog/lading/pull/491 -- that we're still vulnerable to RUSTSEC-2023-0018 by the `tempfile` dependency here. Well, "vulnerable" since we only use `assert_fs` in tests.

The only change I've made is to `let _` the return of `tempfile::TempDir::into_path` per build-time warning.