### PR TITLE
Short-hand to get existing child

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,6 +74,7 @@ pub mod prelude {
     pub use crate::fixture::PathChild;
     pub use crate::fixture::PathCopy;
     pub use crate::fixture::PathCreateDir;
+    pub use crate::fixture::PathExistingChild;
     pub use crate::fixture::SymlinkToDir;
     pub use crate::fixture::SymlinkToFile;
 }


### PR DESCRIPTION
Hi,

First of all, thanks for the great crate!

I often have to touch a path before using it for a current project, so I added this short-hand to my project and then copied it over for this PR.

I kept it simple and didn't bother with trying to create the parent folder or adding a variant like `existing_child_dir`

Tell me what you think